### PR TITLE
Add staroids/namespace

### DIFF
--- a/enterprise/namespace/package.yaml
+++ b/enterprise/namespace/package.yaml
@@ -1,0 +1,5 @@
+name: namespace
+description: Create an empty namespace
+category: others
+logo: https://raw.githubusercontent.com/staroids/community/master/logo/staroid_logo_short.svg
+repository: staroids/namespace


### PR DESCRIPTION
Add github.com/staroids/namespace project to enterprise.
This project is basic building block and enterprise support is provided by staroid.com.

Skipping incubator and production.
