### PR TITLE
Add Cloud9 IDE to incubator list

### DIFF
--- a/incubator/cloud9/package.yaml
+++ b/incubator/cloud9/package.yaml
@@ -1,0 +1,5 @@
+name: cloud9           
+description: Cloud9 IDE
+category: developer
+logo: https://upload.wikimedia.org/wikipedia/commons/5/5f/Cloud9IDE.png 
+repository: sr229/c9-staroid


### PR DESCRIPTION
Adds Cloud9 IDE to the incubator list. This is the version of Cloud 9 IDE based from their Cloud9 Plugin SDK.