### PR TITLE
Add ray-cluster to incubator

### DIFF
--- a/incubator/ray-cluster/package.yaml
+++ b/incubator/ray-cluster/package.yaml
@@ -1,0 +1,5 @@
+name: Ray cluster
+description: Ray (ray.io) cluster with Jupyter notebook and Ray serve endpoint
+category: analytics
+logo: https://ray.io/wp-content/themes/ray/assets/images/ray-logo.svg
+repository: open-datastudio/ray-cluster


### PR DESCRIPTION
Adding [ray](https://ray.io/) cluster support to incubator.
This project supports

 - Creating Ray cluster from official Ray CLI (`ray up` command)
 - Creating Ray cluster from Staroid launch dialog with mouse click
 - Provide a Jupyter notebook
 - Ray Dashboard
 - Ray serve endpoint

